### PR TITLE
Adding ability to rename feeds

### DIFF
--- a/app/routers/feeds.py
+++ b/app/routers/feeds.py
@@ -309,6 +309,20 @@ def update_feed(feed_id: int, body: FeedUpdate, db: Session = Depends(get_db)):
     updates = body.model_dump(exclude_unset=True)
     if "url" in updates and updates["url"]:
         updates["url"] = resolve_feed_url(updates["url"])
+
+    # Handle title rename: pin podcast_group to preserve folder path
+    title_changed = False
+    if "title" in updates:
+        new_title = (updates["title"] or "").strip() or None
+        if new_title != feed.title:
+            old_title = feed.title
+            if not feed.podcast_group and old_title:
+                feed.podcast_group = old_title
+            updates["title"] = new_title
+            title_changed = True
+        else:
+            del updates["title"]  # no actual change
+
     for field, value in updates.items():
         setattr(feed, field, value)
 
@@ -337,6 +351,16 @@ def update_feed(feed_id: int, body: FeedUpdate, db: Session = Depends(get_db)):
         write_folder_metadata(feed, folder)
     except Exception:
         pass
+
+    # Regenerate RSS XML if title changed (so the feed XML reflects the new name)
+    if title_changed:
+        try:
+            from app.downloader import get_podcast_folder
+            from app.rss_generator import write_feed_xml
+            folder = get_podcast_folder(feed, db)
+            write_feed_xml(feed, db, folder)
+        except Exception:
+            pass
 
     return _feed_out(feed, db)
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -108,6 +108,7 @@ class ManualFeedCreate(BaseModel):
 
 
 class FeedUpdate(BaseModel):
+    title: Optional[str] = None
     url: Optional[str] = None
     active: Optional[bool] = None
     download_path: Optional[str] = None

--- a/static/views/feed-detail.js
+++ b/static/views/feed-detail.js
@@ -460,6 +460,12 @@ async function viewFeedDetail(feedId) {
         <div class="panel-body">
           <form id="feed-settings-form">
             <div class="form-group">
+              <label class="form-label">Feed Title</label>
+              <input class="form-control" name="title" type="text"
+                     value="${escHTML(feed.title || "")}" placeholder="${escHTML(feed.url)}" />
+              <div class="form-hint">Change the display name for this podcast.</div>
+            </div>
+            <div class="form-group">
               <label class="form-label">Feed URL</label>
               <input class="form-control" name="url" type="url"
                      value="${feed.url}" />
@@ -1351,9 +1357,16 @@ async function viewFeedDetail(feedId) {
       }
     }
 
+    // Validate title: can't be empty or whitespace
+    if (!(raw.title?.trim())) {
+      Toast.error("Cannot rename feed to invalid name.");
+      return;
+    }
+
     const payload = {
       url: raw.url || feed.url,
       active: feed.active,
+      title: raw.title?.trim() || feed.title,
       id3_enabled: raw.id3_enabled ?? false,
       id3_field_mapping: mapping,
       filename_date_prefix: raw.filename_date_prefix ?? false,
@@ -1387,8 +1400,13 @@ async function viewFeedDetail(feedId) {
     }
 
     try {
-      await API.updateFeed(id, payload);
+      const updated = await API.updateFeed(id, payload);
       Toast.success("Feed settings saved");
+      // Reflect title change in the page header immediately
+      if (payload.title) {
+        const hdr = document.querySelector(".feed-header-title");
+        if (hdr) hdr.textContent = updated.title || updated.url;
+      }
     } catch (err) {
       Toast.error(err.message);
     }


### PR DESCRIPTION
Currently, the only thing that *doesn't* change in the folder name where downloads are stored. This is a minor thing that bothers me a bit, but there are so many additional ways in which this could go wrong during downloads and syncing that I don't want to risk breaking any of it right now. So, folder location stays the same, but everything else is updated in the app (including the same in OPML exports, etc.). Resolves #16