### PR TITLE
Fixing #45

### DIFF
--- a/static/player.js
+++ b/static/player.js
@@ -68,8 +68,10 @@ const Player = (() => {
       if (_currentEp && !_autoPlayedFired && _autoPlayedThreshold > 0 && dur > 0) {
         if ((cur / dur) * 100 >= _autoPlayedThreshold) {
           _autoPlayedFired = true;
-          _pendingPlayed = _currentEp.id;
+          const autoPlayedId = _currentEp.id;
+          _pendingPlayed = autoPlayedId;
           if (navigator.onLine) _flushPlayed();
+          _afterMarkPlayed(autoPlayedId);
         }
       }
 


### PR DESCRIPTION
The fix adds _afterMarkPlayed(autoPlayedId) to the auto-played threshold path. Previously, it was only called when manually executed by user. Closes #45 