### PR TITLE
Adding sync limit option

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -95,6 +95,7 @@ def _migrate_db():
         ("feeds",           "autoclean_enabled",             "BOOLEAN DEFAULT 0"),
         ("feeds",           "autoclean_mode",                "VARCHAR"),
         ("feeds",           "autoclean_exclude",             "BOOLEAN DEFAULT 0"),
+        ("global_settings", "sync_lookback_limit",           "INTEGER DEFAULT 50"),
     ]
     with engine.connect() as conn:
         for table, column, col_def in migrations:

--- a/app/models.py
+++ b/app/models.py
@@ -63,6 +63,9 @@ class GlobalSettings(Base):
     autoclean_mode = Column(String, default="unplayed")
     # Scheduled time to run auto-cleanup (HH:MM in user's timezone)
     autoclean_time = Column(String, default="02:00")
+    # Max RSS entries to inspect on non-initial syncs (0 = unlimited); prevents crawling
+    # deep backlogs on every scheduled sync.  Does not apply to initial syncs or XML imports.
+    sync_lookback_limit = Column(Integer, default=50)
 
 
 class AuthSession(Base):

--- a/app/routers/feeds.py
+++ b/app/routers/feeds.py
@@ -1045,7 +1045,12 @@ def _bg_sync(feed_id: int):
         was_initial = not feed.initial_sync_complete
         log.info("Syncing: %s (id=%d)", feed.title or feed.url, feed_id)
         try:
-            sync_feed_episodes(feed, db)
+            lookback = None
+            if not was_initial:
+                settings = db.query(GlobalSettings).first()
+                limit = settings.sync_lookback_limit if settings else 50
+                lookback = limit if limit and limit > 0 else None
+            sync_feed_episodes(feed, db, lookback_limit=lookback)
             feed.last_error = None
         except Exception as e:
             feed.last_error = str(e)

--- a/app/rss_parser.py
+++ b/app/rss_parser.py
@@ -329,11 +329,15 @@ def sync_feed_episodes(
     parse_url: Optional[str] = None,
     xml_import: bool = False,
     resolutions: Optional[dict] = None,
+    lookback_limit: Optional[int] = None,
 ) -> tuple[list[int], int]:
     """Fetch feed, upsert episodes into DB.
 
     parse_url: if given, parse this URL/path instead of feed.url (e.g. a local
     complete-feed.xml). Feed metadata fields are not updated when parse_url is used.
+    lookback_limit: when set (and > 0), only the first N entries from the RSS feed
+    are inspected.  This prevents crawling deep backlogs on routine syncs.  Has no
+    effect during initial syncs or XML imports (callers should not pass it then).
     Returns IDs of newly added episodes whose status is 'pending'.
     """
     source = parse_url or feed.url
@@ -426,7 +430,11 @@ def sync_feed_episodes(
     new_pending_episodes: list[Episode] = []
     skipped_count = 0
 
-    for entry in parsed.entries:
+    entries = parsed.entries
+    if lookback_limit and lookback_limit > 0:
+        entries = entries[:lookback_limit]
+
+    for entry in entries:
         guid = getattr(entry, "id", None) or getattr(entry, "guid", None)
         enc_url, enc_type, enc_len = _entry_enclosure(entry)
         pub = _parse_date(getattr(entry, "published_parsed", None))

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -37,6 +37,7 @@ class GlobalSettingsBase(BaseModel):
     autoclean_enabled: bool = False
     autoclean_mode: str = "unplayed"
     autoclean_time: str = "02:00"
+    sync_lookback_limit: int = 50
 
 
 class GlobalSettingsUpdate(BaseModel):
@@ -69,6 +70,7 @@ class GlobalSettingsUpdate(BaseModel):
     autoclean_enabled: Optional[bool] = None
     autoclean_mode: Optional[str] = None
     autoclean_time: Optional[str] = None
+    sync_lookback_limit: Optional[int] = None
 
 
 class GlobalSettingsOut(GlobalSettingsBase):

--- a/static/views/settings.js
+++ b/static/views/settings.js
@@ -258,6 +258,14 @@ async function viewSettings() {
               </div>
             </div>
 
+            <div class="form-group">
+              <label class="form-label">Sync Lookback Limit</label>
+              <input class="form-control" name="sync_lookback_limit" type="number"
+                     min="0" value="${settings.sync_lookback_limit ?? 50}" data-numeric="1"
+                     style="max-width:120px" />
+              <div class="form-hint">Maximum number of RSS entries to inspect on each routine sync. Set to 0 for unlimited. Has no effect on the initial sync when a feed is first added, or when importing from XML. Default: 50.</div>
+            </div>
+
             ${toggle("Auto-download new episodes", "auto_download_new",
               settings.auto_download_new,
               "Automatically queue new episodes for download when first detected (does not apply to the initial import when a feed is added.")}
@@ -491,6 +499,7 @@ async function viewSettings() {
       organize_by_year: raw.organize_by_year ?? false,
       save_xml: raw.save_xml ?? false,
       auto_download_new: raw.auto_download_new ?? true,
+      sync_lookback_limit: Number(raw.sync_lookback_limit) ?? 50,
       default_id3_mapping: id3Mapping,
       log_max_entries: Number(raw.log_max_entries) || 500,
       episode_page_size: Number(raw.episode_page_size) || 10000,


### PR DESCRIPTION
Helps to speed things up for extremely long feeds where, once we've done an initially long sync, we don't need to sync another 10 pages of episodes, etc. Basically, we don't need a comprehensive sync each time after the initial sync because 1) we already have that information, 2) we don't want things to get goofy if older information changes, and 3) we want to be respectful and not hammer a feed with dozens of sequential requests if it has a long history. Closes #48.

Also, added setting to be able to change the default (50 items), plus some migration logic if updating from older install.