### PR TITLE
Snappier deletion from feed details page

### DIFF
--- a/app/routers/feeds.py
+++ b/app/routers/feeds.py
@@ -401,9 +401,29 @@ def delete_feed(feed_id: int, delete_files: bool = False, force: bool = False, d
                     except OSError:
                         pass
 
+        # Remove app-generated non-audio files that the episode loop doesn't cover
+        if podcast_folder and os.path.isdir(podcast_folder):
+            for fname in ("cover.jpg", "complete-feed.xml", "castcharm.json"):
+                p = os.path.join(podcast_folder, fname)
+                if os.path.exists(p):
+                    try:
+                        os.remove(p)
+                    except OSError:
+                        pass
+
         # Remove the entire podcast folder (user explicitly chose "delete all files")
         if podcast_folder and os.path.isdir(podcast_folder):
-            shutil.rmtree(podcast_folder, ignore_errors=True)
+            try:
+                shutil.rmtree(podcast_folder)
+            except OSError as exc:
+                log.warning("Could not fully remove podcast folder %s: %s", podcast_folder, exc)
+                # Best-effort: prune any directories that are now empty (e.g. year subdirs)
+                for dirpath, _dirs, _files in os.walk(podcast_folder, topdown=False):
+                    try:
+                        if not os.listdir(dirpath):
+                            os.rmdir(dirpath)
+                    except OSError:
+                        pass
 
     if force:
         try:

--- a/static/views/feed-detail.js
+++ b/static/views/feed-detail.js
@@ -3081,28 +3081,19 @@ function showDeleteFeedModal(feed) {
     (body) => {
       body.querySelector("#btn-confirm-delete").addEventListener("click", async () => {
         const deleteFiles = body.querySelector("#chk-delete-files").checked;
+        Modal.close();
+        window._deletingFeedIds = window._deletingFeedIds || new Set();
+        window._deletingFeedIds.add(feed.id);
+        Router.navigate("/feeds");
         try {
-          await API.request("DELETE", `/api/feeds/${feed.id}?delete_files=${deleteFiles}`);
-          Modal.close();
+          await API.deleteFeed(feed.id, deleteFiles);
           Toast.success(deleteFiles ? "Feed and files deleted" : "Feed deleted");
-          Router.navigate("/feeds");
+          window._deletingFeedIds.delete(feed.id);
+          if (typeof _refreshFeedsGrid === "function") await _refreshFeedsGrid();
         } catch (e) {
-          const errDiv = body.querySelector("#delete-error");
-          errDiv.innerHTML = `
-            <div style="color:var(--error);margin-bottom:10px;font-size:13px">⚠ ${e.message}</div>
-            <p style="color:var(--text-2);font-size:13px;margin-bottom:12px">
-              Force delete will remove the feed directly from the database,
-              bypassing normal checks. This cannot be undone.
-            </p>
-            <button class="btn btn-danger btn-sm" id="btn-force-delete">Force Delete</button>`;
-          body.querySelector("#btn-force-delete").addEventListener("click", async () => {
-            try {
-              await API.request("DELETE", `/api/feeds/${feed.id}?delete_files=${deleteFiles}&force=true`);
-              Modal.close();
-              Toast.success("Feed force-deleted");
-              Router.navigate("/feeds");
-            } catch (e2) { Toast.error(`Force delete failed: ${e2.message}`); }
-          });
+          window._deletingFeedIds.delete(feed.id);
+          Toast.error(`Delete failed: ${e.message}`);
+          if (typeof _refreshFeedsGrid === "function") await _refreshFeedsGrid();
         }
       });
     }

--- a/static/views/feeds.js
+++ b/static/views/feeds.js
@@ -82,6 +82,25 @@ function _flipReorderGrid(sortedFeeds) {
   }, 350);
 }
 
+function _applyDeletingOverlays() {
+  const ids = window._deletingFeedIds;
+  if (!ids?.size) return;
+  for (const id of ids) {
+    const card = document.querySelector(`.feed-card[data-id="${id}"]`);
+    if (!card || card.querySelector(".feed-card-deleting")) continue;
+    card.style.pointerEvents = "none";
+    card.insertAdjacentHTML("beforeend", `
+      <div class="feed-card-deleting" style="position:absolute;inset:0;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,0.55);border-radius:inherit;z-index:10">
+        <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" width="36" height="36" style="opacity:0.85">
+          <polyline points="3 6 5 6 21 6"/>
+          <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/>
+          <path d="M10 11v6"/><path d="M14 11v6"/>
+          <path d="M9 6V4h6v2"/>
+        </svg>
+      </div>`);
+  }
+}
+
 async function _refreshFeedsGrid() {
   const feeds = await API.getFeeds();
   _feedsData = feeds;
@@ -94,6 +113,7 @@ async function _refreshFeedsGrid() {
     return;
   }
   grid.innerHTML = _sortFeeds(feeds).map(feedCard).join("");
+  _applyDeletingOverlays();
   const sub = document.querySelector(".page-subtitle");
   if (sub) sub.textContent = `${feeds.length} podcast${feeds.length !== 1 ? "s" : ""}`;
 }
@@ -237,6 +257,7 @@ async function viewFeeds() {
           </div>`}
     </div>`;
 
+  _applyDeletingOverlays();
   document.getElementById("btn-add-feed")?.addEventListener("click", showAddFeedModal);
   document.getElementById("btn-add-feed-empty")?.addEventListener("click", showAddFeedModal);
 


### PR DESCRIPTION
Closes #53 by kicking user back to the Feeds page and refreshing the cards to ensure that the UI doesn't freeze while processing the deletion. Also, some attempts to make the actual deletion process a bit more robus with logging as well.