### PR TITLE
Fixing mark (un)played in the api

### DIFF
--- a/app/routers/episodes.py
+++ b/app/routers/episodes.py
@@ -655,6 +655,10 @@ def toggle_played(episode_id: int, db: Session = Depends(get_db)):
     ep.played = not ep.played
     if ep.played:
         ep.last_played_at = datetime.utcnow()
+        if ep.duration:
+            ep.play_position_seconds = ep.duration
+    else:
+        ep.play_position_seconds = 0
     db.commit()
     db.refresh(ep)
     log.info("Episode marked %s: '%s' (ep %d)", "played" if ep.played else "unplayed", ep.title or "Untitled", episode_id)


### PR DESCRIPTION
Making sure that everything is consistently implemented through the API. Marking as played via the API didn't necessarily set playback status to 100%.