### PR TITLE
Fixing feed URL change sync and stale cancel signal bugs

### DIFF
--- a/app/downloader.py
+++ b/app/downloader.py
@@ -179,10 +179,19 @@ def _ensure_workers() -> None:
 
 
 
-def enqueue_download(episode_id: int) -> None:  # noqa: ARG001
+def enqueue_download(episode_id: int) -> None:
     """Wake the download workers.  They will claim the next episode from the DB in
     priority order (newest published_at first), so submission order no longer
-    determines download order."""
+    determines download order.
+
+    Also clears any stale cancel signal for this ID.  _cancelled_ids is a
+    process-lifetime set — cancel endpoints that reset queued-state episodes
+    straight to pending never go through the worker, so their IDs accumulate
+    in the set forever.  After a feed delete + re-add, SQLite's ROWID reuse
+    can hand those IDs to completely unrelated new episodes; without this
+    discard, their first queue attempt would be instantly cancelled.
+    """
+    _cancelled_ids.discard(episode_id)
     _ensure_workers()
     _wake_event.set()
 

--- a/app/routers/feeds.py
+++ b/app/routers/feeds.py
@@ -301,14 +301,17 @@ def get_feed(feed_id: int, db: Session = Depends(get_db)):
 
 
 @router.put("/{feed_id}", response_model=FeedOut)
-def update_feed(feed_id: int, body: FeedUpdate, db: Session = Depends(get_db)):
+def update_feed(feed_id: int, body: FeedUpdate, background_tasks: BackgroundTasks, db: Session = Depends(get_db)):
     feed = db.query(Feed).filter(Feed.id == feed_id).first()
     if not feed:
         raise HTTPException(status_code=404, detail="Feed not found")
 
     updates = body.model_dump(exclude_unset=True)
+    url_changed = False
     if "url" in updates and updates["url"]:
         updates["url"] = resolve_feed_url(updates["url"])
+        if updates["url"] != feed.url:
+            url_changed = True
 
     # Handle title rename: pin podcast_group to preserve folder path
     title_changed = False
@@ -325,6 +328,11 @@ def update_feed(feed_id: int, body: FeedUpdate, db: Session = Depends(get_db)):
 
     for field, value in updates.items():
         setattr(feed, field, value)
+
+    if url_changed:
+        # Treat the new URL as a fresh feed: full sync (no lookback limit), no auto-download.
+        feed.initial_sync_complete = False
+        feed.download_all_on_first_sync = False
 
     feed.updated_at = datetime.utcnow()
     db.commit()
@@ -361,6 +369,12 @@ def update_feed(feed_id: int, body: FeedUpdate, db: Session = Depends(get_db)):
             write_feed_xml(feed, db, folder)
         except Exception:
             pass
+
+    # Kick off an immediate sync when the URL changed so the new feed is populated right away.
+    if url_changed:
+        from app.activity import mark_sync_queued
+        mark_sync_queued(feed_id)
+        background_tasks.add_task(_bg_sync, feed_id)
 
     return _feed_out(feed, db)
 

--- a/app/rss_parser.py
+++ b/app/rss_parser.py
@@ -4,8 +4,9 @@ import hashlib
 import json
 import logging
 import re
+import unicodedata
 import urllib.request
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Optional
 
 log = logging.getLogger(__name__)
@@ -14,6 +15,21 @@ import feedparser
 
 from app.models import Episode, Feed
 from sqlalchemy.orm import Session
+
+
+def _normalize_title(title: Optional[str]) -> str:
+    """Case/punctuation-insensitive normalisation for fuzzy title matching.
+
+    Used by the sync-time dedup so that when a feed's URL points at a different
+    source, slight formatting differences between the two feeds (colon vs dash,
+    smart quotes, extra whitespace) don't produce phantom "pending" duplicates
+    of episodes we already have downloaded.
+    """
+    if not title:
+        return ""
+    title = unicodedata.normalize("NFKD", title).encode("ascii", "ignore").decode()
+    title = re.sub(r"[^a-z0-9 ]", " ", title.lower())
+    return re.sub(r"\s+", " ", title).strip()
 
 
 def _parse_date(val) -> Optional[datetime]:
@@ -398,7 +414,10 @@ def sync_feed_episodes(
         ).all()
     ]
 
-    # Build enclosure URL map and title+date map from sibling feeds in the same group
+    # Build enclosure URL map and title+date map from sibling feeds in the same group.
+    # Title keys go through _normalize_title so fuzzy variations ("Ep 1: Foo" vs
+    # "Ep. 1 - Foo") match.  Date keys are looked up with ±1 day tolerance further
+    # down to absorb timezone-parse slop between sources.
     existing_url_map: dict[str, Episode] = {}
     existing_title_date_map: dict[tuple, Episode] = {}
     if sibling_ids:
@@ -407,8 +426,9 @@ def sync_feed_episodes(
         ).all():
             if ep.enclosure_url:
                 existing_url_map[ep.enclosure_url] = ep
-            if ep.title and ep.published_at:
-                key = (ep.title.strip().lower(), ep.published_at.date())
+            norm = _normalize_title(ep.title)
+            if norm and ep.published_at:
+                key = (norm, ep.published_at.date())
                 existing_title_date_map.setdefault(key, ep)
 
     # Build same-feed maps for dedup and xml_import collision resolution.
@@ -419,13 +439,34 @@ def sync_feed_episodes(
     for ep in db.query(Episode).filter(Episode.feed_id == feed.id).all():
         if ep.enclosure_url:
             same_feed_url_map[ep.enclosure_url] = ep
-        if ep.title and ep.published_at:
-            key = (ep.title.strip().lower(), ep.published_at.date())
+        norm = _normalize_title(ep.title)
+        if norm and ep.published_at:
+            key = (norm, ep.published_at.date())
             same_feed_title_date_map.setdefault(key, ep)
         if ep.guid:
             same_feed_guid_map[ep.guid] = ep
-        if ep.title:
-            same_feed_title_map.setdefault(ep.title.strip().lower(), ep)
+        if norm:
+            same_feed_title_map.setdefault(norm, ep)
+
+    def _lookup_by_title_date(
+        tmap: dict[tuple, "Episode"],
+        t: Optional[str],
+        p: Optional[datetime],
+    ) -> Optional["Episode"]:
+        """Fuzzy title+date lookup: normalised title must match; date within ±1 day.
+
+        The ±1 day window lets us dedup when two sources of the same feed disagree
+        on publish date by a few hours across a midnight boundary.
+        """
+        norm = _normalize_title(t)
+        if not norm or p is None:
+            return None
+        d = p.date()
+        for delta in (0, -1, 1):
+            match = tmap.get((norm, d + timedelta(days=delta)))
+            if match is not None:
+                return match
+        return None
 
     new_pending_episodes: list[Episode] = []
     skipped_count = 0
@@ -521,8 +562,8 @@ def sync_feed_episodes(
             # this RSS entry by enclosure URL or title+date, promote it to the real
             # guid instead of creating a duplicate.
             same_match = same_feed_url_map.get(enc_url) if enc_url else None
-            if same_match is None and title and pub:
-                same_match = same_feed_title_date_map.get((title.strip().lower(), pub.date()))
+            if same_match is None:
+                same_match = _lookup_by_title_date(same_feed_title_date_map, title, pub)
             if same_match is not None and same_match.guid != guid:
                 old_guid = same_match.guid
                 same_match.guid = guid
@@ -536,8 +577,8 @@ def sync_feed_episodes(
 
             # Cross-feed dedup: URL match takes priority, then title+date match
             duplicate = existing_url_map.get(enc_url) if enc_url else None
-            if duplicate is None and title and pub:
-                duplicate = existing_title_date_map.get((title.strip().lower(), pub.date()))
+            if duplicate is None:
+                duplicate = _lookup_by_title_date(existing_title_date_map, title, pub)
 
             if duplicate is not None:
                 if duplicate.status == "downloaded" and duplicate.file_path:


### PR DESCRIPTION
A pretty big overhaul of some deeply buried logic around feed locations, episode tracking, and syncing. Changing a feed's URL did not reset initial_sync_complete, so the next sync treated it as a routine check-in: only sync_lookback_limit (default 50) entries were inspected instead of the full feed, and auto_download_new fired for those newly-found episodes — causing unexpected downloads. update_feed now resets initial_sync_complete and download_all_on_first_sync when the URL actually changes, and kicks off an immediate background sync so the new feed populates without waiting for the scheduler. As a second part of this - After deleting a feed and re-adding it, the first 'Download All' would queue every episode and then instantly clear the queue with no network activity and no Failed entries; a second attempt worked. Root cause: _cancelled_ids is a process-lifetime set, populated by request_cancel() but only cleared inside download_episode(). Cancel endpoints that reset queued-state rows straight to 'pending' never route through the worker, so their IDs accumulated in the set forever. SQLite reuses ROWIDs after delete-orphan cascades, so new episodes inherited stale cancel markers and were reset to pending the instant the worker tried to download them. enqueue_download() now discards the ID from _cancelled_ids before waking the workers. Lastly, changing a feed's URL would cause the next sync to create phantom 'pending' duplicates of episodes already downloaded from the old URL. The sync-time title+date dedup was keyed on raw title + exact date, so slight title formatting differences between sources or timezone-parse slop across a midnight boundary would defeat the match. Title keys now go through a Unicode-normalised, punctuation-stripped form, and date lookup accepts a plus-or-minus 1 day window. Closes #70.