### PR TITLE
Working on the android app, I came across issues with duplicate/stale…

### DIFF
--- a/app/routers/feeds.py
+++ b/app/routers/feeds.py
@@ -167,6 +167,46 @@ def _check_title_conflict(title: str, db: Session, exclude_id: int | None = None
     return None
 
 
+def _existing_folder_conflict(
+    title: str, db: Session, feed: Feed | None = None
+) -> tuple[str, int] | None:
+    """Return (path, file_count) when a download folder for *title* already has files.
+
+    Podcast folders are named after the title, so a podcast that was removed while
+    its audio was kept leaves a folder that a later, unrelated podcast of the same
+    name would silently adopt — inheriting its files and its cover art. Detecting it
+    lets the caller ask the user instead of guessing.
+
+    Empty directories are ignored: nothing can be inherited from them, so prompting
+    would be noise.
+    """
+    from app.downloader import sanitize_filename
+
+    folder_name = sanitize_filename(title)
+    if not folder_name:
+        return None
+
+    # Honour a per-feed download_path override; otherwise the global setting. Without
+    # this, a feed filed under a custom directory would be checked against the wrong
+    # place — reporting a phantom clash, or missing a real one.
+    gs = db.query(GlobalSettings).first()
+    base_dir = (
+        (feed.download_path if feed else None)
+        or (gs.download_path if gs else None)
+        or "/downloads"
+    )
+    path = os.path.join(base_dir, folder_name)
+    if not os.path.isdir(path):
+        return None
+
+    try:
+        count = sum(len(files) for _root, _dirs, files in os.walk(path))
+    except OSError:
+        return None
+
+    return (path, count) if count > 0 else None
+
+
 @router.get("", response_model=list[FeedOut])
 def list_feeds(db: Session = Depends(get_db)):
     feeds = db.query(Feed).filter(Feed.primary_feed_id.is_(None)).order_by(Feed.title).all()
@@ -230,6 +270,33 @@ def add_feed(body: FeedCreate, background_tasks: BackgroundTasks, db: Session = 
                 status_code=409,
                 detail={"message": "A podcast with this name already exists.", "conflict_title": folder_name},
             )
+
+        # No live feed owns the name, but a folder from a previously removed podcast
+        # may still be sitting there. Adopting it silently would mix two podcasts'
+        # files together and hand the new one the old one's cover art, so ask first.
+        # conflict_title is included so existing clients route this into the same
+        # "pick another name" flow they already use for the conflict above.
+        if not body.allow_existing_folder:
+            existing_folder = _existing_folder_conflict(folder_name, db)
+            if existing_folder:
+                path, file_count = existing_folder
+                db.rollback()
+                raise HTTPException(
+                    status_code=409,
+                    detail={
+                        "message": (
+                            f'A folder named "{folder_name}" already exists and contains '
+                            f'{file_count} file{"" if file_count == 1 else "s"}. It is probably '
+                            "left over from a podcast that was removed without deleting its "
+                            "files. Choose a different folder name, or use this folder anyway."
+                        ),
+                        "conflict_title": folder_name,
+                        "folder_conflict": True,
+                        "folder_path": path,
+                        "file_count": file_count,
+                    },
+                )
+
     if body.title_override:
         feed.podcast_group = body.title_override.strip()
 
@@ -250,6 +317,26 @@ def add_manual_feed(body: ManualFeedCreate, db: Session = Depends(get_db)):
     """Create a feed entry without an RSS URL (e.g. for defunct/offline podcasts)."""
     import uuid
     title = body.title.strip()
+    # Same folder guard as add_feed: a manual podcast is filed by title too, so it can
+    # land on a directory left behind by one that was removed.
+    if not body.allow_existing_folder:
+        existing_folder = _existing_folder_conflict(title, db)
+        if existing_folder:
+            path, file_count = existing_folder
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "message": (
+                        f'A folder named "{title}" already exists and contains '
+                        f'{file_count} file{"" if file_count == 1 else "s"}. Choose a different '
+                        "name, or use this folder anyway."
+                    ),
+                    "conflict_title": title,
+                    "folder_conflict": True,
+                    "folder_path": path,
+                    "file_count": file_count,
+                },
+            )
     conflict = _check_title_conflict(title, db)
     if conflict:
         raise HTTPException(
@@ -307,11 +394,66 @@ def update_feed(feed_id: int, body: FeedUpdate, background_tasks: BackgroundTask
         raise HTTPException(status_code=404, detail="Feed not found")
 
     updates = body.model_dump(exclude_unset=True)
+    # Not a column on Feed — must come out before the setattr loop below, which would
+    # otherwise try to assign it to the model.
+    allow_existing_folder = bool(updates.pop("allow_existing_folder", False))
+
     url_changed = False
     if "url" in updates and updates["url"]:
         updates["url"] = resolve_feed_url(updates["url"])
         if updates["url"] != feed.url:
             url_changed = True
+
+    # A folder move is driven solely by podcast_group. A title rename does NOT move
+    # the folder — the block below pins podcast_group to the old title precisely to
+    # keep the path stable — so only an explicit podcast_group change is checked.
+    #
+    # Guarded exactly like creation: refuse to point this podcast at a folder another
+    # live podcast owns, or at a directory left behind by one that was removed. Note
+    # that renaming never moves existing files, so the podcast would simply start
+    # writing into someone else's directory.
+    #
+    # Runs before any field is applied, so there is nothing to roll back on refusal.
+    if "podcast_group" in updates:
+        from app.downloader import sanitize_filename
+
+        new_folder_name = (updates["podcast_group"] or feed.title or "").strip()
+        current_folder_name = (feed.podcast_group or feed.title or "").strip()
+        moved = (
+            sanitize_filename(new_folder_name).lower()
+            != sanitize_filename(current_folder_name).lower()
+        )
+
+        if new_folder_name and moved:
+            conflict = _check_title_conflict(new_folder_name, db, exclude_id=feed.id)
+            if conflict:
+                raise HTTPException(
+                    status_code=409,
+                    detail={
+                        "message": "A podcast with this name already exists.",
+                        "conflict_title": new_folder_name,
+                    },
+                )
+
+            if not allow_existing_folder:
+                existing_folder = _existing_folder_conflict(new_folder_name, db, feed)
+                if existing_folder:
+                    path, file_count = existing_folder
+                    raise HTTPException(
+                        status_code=409,
+                        detail={
+                            "message": (
+                                f'A folder named "{new_folder_name}" already exists and contains '
+                                f'{file_count} file{"" if file_count == 1 else "s"}. Renaming this '
+                                "podcast into it would mix the two together — existing files are "
+                                "not moved. Choose a different name, or use this folder anyway."
+                            ),
+                            "conflict_title": new_folder_name,
+                            "folder_conflict": True,
+                            "folder_path": path,
+                            "file_count": file_count,
+                        },
+                    )
 
     # Handle title rename: pin podcast_group to preserve folder path
     title_changed = False
@@ -415,7 +557,11 @@ def delete_feed(feed_id: int, delete_files: bool = False, force: bool = False, d
                     except OSError:
                         pass
 
-        # Remove app-generated non-audio files that the episode loop doesn't cover
+        # Remove app-generated non-audio files that the episode loop doesn't cover.
+        # Deliberately confined to the delete_files branch: cover.jpg is where
+        # upload_feed_cover() stores user-uploaded artwork, so it is not always
+        # something this app generated, and a delete that promised to keep the
+        # user's files must not quietly remove it.
         if podcast_folder and os.path.isdir(podcast_folder):
             for fname in ("cover.jpg", "complete-feed.xml", "castcharm.json"):
                 p = os.path.join(podcast_folder, fname)
@@ -1439,6 +1585,7 @@ def run_feed_autoclean(feed_id: int, db: Session = Depends(get_db)):
 async def create_feed_from_xml(
     file: UploadFile = File(...),
     title_override: Optional[str] = Form(None),
+    allow_existing_folder: bool = Form(False),
     db: Session = Depends(get_db),
 ):
     """Create a new podcast feed by uploading a local RSS/XML file.
@@ -1489,6 +1636,24 @@ async def create_feed_from_xml(
                              or (itunes_img if isinstance(itunes_img, str) else None))
 
         # Check for folder-name conflict before committing anything
+        if not allow_existing_folder:
+            existing_folder = _existing_folder_conflict(feed_title, db)
+            if existing_folder:
+                path, file_count = existing_folder
+                raise HTTPException(
+                    status_code=409,
+                    detail={
+                        "message": (
+                            f'A folder named "{feed_title}" already exists and contains '
+                            f'{file_count} file{"" if file_count == 1 else "s"}. Choose a '
+                            "different name, or use this folder anyway."
+                        ),
+                        "conflict_title": feed_title,
+                        "folder_conflict": True,
+                        "folder_path": path,
+                        "file_count": file_count,
+                    },
+                )
         conflict = _check_title_conflict(feed_title, db)
         if conflict:
             raise HTTPException(

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -137,6 +137,10 @@ class FeedCreate(BaseModel):
     url: str
     download_all: bool = False
     title_override: Optional[str] = None
+    # Set only after the user has been shown the folder-already-exists prompt and
+    # has chosen to go ahead. Without it the add is refused with a 409 so the
+    # decision is never made on their behalf.
+    allow_existing_folder: bool = False
 
     @field_validator("url")
     @classmethod
@@ -149,6 +153,8 @@ class FeedCreate(BaseModel):
 
 class ManualFeedCreate(BaseModel):
     title: str
+    # See FeedCreate.allow_existing_folder.
+    allow_existing_folder: bool = False
 
     @field_validator("title")
     @classmethod
@@ -180,6 +186,10 @@ class FeedUpdate(BaseModel):
     autoclean_enabled: Optional[bool] = None
     autoclean_mode: Optional[str] = None
     autoclean_exclude: Optional[bool] = None
+    # Not a Feed column. Set only after the user has been shown the
+    # folder-already-exists prompt for a podcast_group rename and chosen to proceed;
+    # update_feed() pops it before applying the rest of the fields.
+    allow_existing_folder: bool = False
 
 
 class FeedOut(BaseModel):

--- a/static/api.js
+++ b/static/api.js
@@ -81,7 +81,14 @@ const API = {
 
   // ── Feeds ────────────────────────────────────────────────────
   getFeeds:     () =>         API.get("/api/feeds"),
-  addFeed:         (url, downloadAll = false, titleOverride = null) => API.post("/api/feeds", { url, download_all: downloadAll, title_override: titleOverride || undefined }),
+  addFeed:         (url, downloadAll = false, titleOverride = null, allowExistingFolder = false) =>
+    API.post("/api/feeds", {
+      url,
+      download_all: downloadAll,
+      title_override: titleOverride || undefined,
+      // Only ever true after the user has been shown the folder-conflict prompt.
+      allow_existing_folder: allowExistingFolder || undefined,
+    }),
   addManualFeed:   (title) =>   API.post("/api/feeds/manual", { title }),
   createFeedFromXml: (file, titleOverride) => _upload("/api/feeds/from-xml", "file", file, titleOverride ? { title_override: titleOverride } : null),
   getFeed:      (id) =>       API.get(`/api/feeds/${id}`),

--- a/static/views/feeds.js
+++ b/static/views/feeds.js
@@ -536,7 +536,17 @@ function showAddFeedModal() {
         try { feed = await API.addFeed(url, chkDlAll.checked); }
         catch (e) {
           if (e.conflict_title != null) {
-            goTo("rss-rename", { url, downloadAll: chkDlAll.checked, conflictTitle: e.conflict_title });
+            goTo("rss-rename", {
+              url,
+              downloadAll: chkDlAll.checked,
+              conflictTitle: e.conflict_title,
+              // Present only when the clash is a leftover folder on disk rather than
+              // another live podcast — the two need different wording, and only the
+              // folder case can be resolved by using it anyway.
+              folderConflict: e.folder_conflict === true,
+              folderPath: e.folder_path || null,
+              fileCount: e.file_count || 0,
+            });
             return;
           }
           errEl.textContent = e.message; errEl.style.display = "block";
@@ -556,13 +566,22 @@ function showAddFeedModal() {
 
     // ── Step 3a: RSS folder-name conflict rename ─────────────────────────
     else if (step === "rss-rename") {
-      const { url, downloadAll, conflictTitle } = data;
-      document.getElementById("modal-title").textContent = "Name Already In Use";
+      const { url, downloadAll, conflictTitle, folderConflict, folderPath, fileCount } = data;
+      document.getElementById("modal-title").textContent =
+        folderConflict ? "Folder Already Exists" : "Name Already In Use";
+      const intro = folderConflict
+        ? `A folder named <strong>${escHTML(conflictTitle)}</strong> already exists and contains
+           <strong>${fileCount}</strong> file${fileCount === 1 ? "" : "s"}. It's most likely left
+           over from a podcast that was removed without deleting its files.<br><br>
+           Enter a different folder name for this podcast, or use the existing folder anyway
+           (its files will be mixed in with this podcast's).`
+        : `A podcast named <strong>${escHTML(conflictTitle)}</strong> already exists.
+           Enter an alternative name for the new podcast's folder:`;
       B.innerHTML = `
         <p style="color:var(--text-2);font-size:13px;margin:0 0 14px;line-height:1.5">
-          A podcast named <strong>${conflictTitle}</strong> already exists.
-          Enter an alternative name for the new podcast's folder:
+          ${intro}
         </p>
+        ${folderConflict && folderPath ? `<div class="form-hint" style="margin:-8px 0 12px;word-break:break-all">${escHTML(folderPath)}</div>` : ""}
         <div class="form-group">
           <input class="form-control" id="rss-rename-input" type="text" value="${conflictTitle}" autocomplete="off" />
           <div class="form-hint" style="margin-top:5px">This name is used as the folder name only — the podcast title from the feed is kept as-is.</div>
@@ -570,12 +589,29 @@ function showAddFeedModal() {
         <div id="rss-rename-err" style="color:var(--error);font-size:13px;display:none;margin-bottom:8px"></div>
         <div class="modal-actions">
           <button class="btn btn-ghost" id="btn-wiz-back">Back</button>
+          ${folderConflict ? `<button class="btn btn-ghost" id="btn-rss-use-folder">Use Existing Folder</button>` : ""}
           <button class="btn btn-primary" id="btn-rss-rename-confirm">Add Podcast</button>
         </div>`;
       const nameIn = B.querySelector("#rss-rename-input");
       const errEl2 = B.querySelector("#rss-rename-err");
       B.querySelector("#btn-wiz-back").addEventListener("click", () => goTo("rss"));
       nameIn.select();
+
+      // Deliberate opt-in: keep the detected name, but tell the server the existing
+      // folder is acceptable so it stops refusing.
+      B.querySelector("#btn-rss-use-folder")?.addEventListener("click", async () => {
+        const btn = B.querySelector("#btn-rss-use-folder");
+        btn.disabled = true; btn.textContent = "Adding…"; errEl2.style.display = "none";
+        let feed;
+        try { feed = await API.addFeed(url, downloadAll, null, true); }
+        catch (e) {
+          errEl2.textContent = e.message; errEl2.style.display = "block";
+          btn.disabled = false; btn.textContent = "Use Existing Folder"; return;
+        }
+        Modal.close();
+        Toast.success("Podcast added — using the existing folder");
+        await _refreshFeedsGrid();
+      });
 
       async function submitRename() {
         const altName = nameIn.value.trim();


### PR DESCRIPTION
… images from previously deleted feeds with the same name. Fell down a rabbit hole and realized that if a feed is deleted, then another feed with the same name is added, it'll absorb the data from the previous feed *if* those files are still on disk (i.e., if the feed was deleted from the server but the user opts to retain the files rather than delete them all). So, reworked some stuff around that. Kind of an edge case, and there are probably other QoL things to do here around renaming folders if the user renames the podcast (currently it doesn't), but I want to actually plan that out so that nothing goes crazy if exceptions occur mid-migration, etc. etc. It's a really big thing that could go wrong like 50 ways, and I don't have the brain power for it at the moment.