### PR TITLE
fixing lots of 3rd party reqs

### DIFF
--- a/app/downloader.py
+++ b/app/downloader.py
@@ -395,6 +395,83 @@ def _build_file_path(
 AUDIO_EXTENSIONS = {".mp3", ".m4a", ".aac", ".ogg", ".flac", ".wav", ".mp4", ".opus", ".wma"}
 
 
+COVER_FILENAME = "cover.jpg"
+
+# Records the URL a cover.jpg was fetched from. Its ABSENCE beside an existing
+# cover means a person put that file there — through upload_feed_cover, or by
+# dropping it into the folder — so a refresh must leave it alone. Its presence
+# means we fetched it, and may replace it when the podcast's artwork moves.
+COVER_SOURCE_FILENAME = ".cover-source"
+
+
+def read_cover_source(folder: str) -> Optional[str]:
+    """The URL this folder's cover was fetched from, or None if user-supplied."""
+    try:
+        with open(os.path.join(folder, COVER_SOURCE_FILENAME), encoding="utf-8") as f:
+            return f.read().strip() or None
+    except Exception:
+        return None
+
+
+def clear_cover_source(folder: str) -> None:
+    """Mark this folder's cover as user-owned, so refreshes never overwrite it."""
+    try:
+        os.remove(os.path.join(folder, COVER_SOURCE_FILENAME))
+    except FileNotFoundError:
+        pass
+    except Exception as exc:
+        log.warning("Could not clear cover source marker in %s: %s", folder, exc)
+
+
+def ensure_feed_cover(feed, folder: str) -> bool:
+    """
+    Make sure this feed's artwork is on disk. Returns True if a file was written.
+
+    Artwork used to reach the disk only as a side effect of downloading an
+    episode, so a feed nobody had downloaded from served its RSS artwork URL
+    straight to the browser. That made every client fetch art from the podcast
+    host directly — disclosing the user's IP address and their browsing times to
+    a third party on every render of the feed list, and leaving the page reliant
+    on that host being reachable. Anything an http:// URL simply failed to load
+    at all, because the page's CSP allows https only.
+    """
+    art_url = feed.custom_image_url or feed.image_url
+    if not art_url:
+        return False
+
+    cover_path = os.path.join(folder, COVER_FILENAME)
+    if os.path.exists(cover_path):
+        source = read_cover_source(folder)
+        if source is None or source == art_url:
+            # User-supplied, or already the artwork we would fetch.
+            return False
+
+    # Fetched to one side and moved into place only on success, so a host that
+    # is down or has pulled the image leaves the existing cover untouched
+    # rather than trading it for nothing.
+    tmp_path = cover_path + ".tmp"
+    try:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+    except Exception:
+        pass
+
+    _download_image(art_url, tmp_path)
+    if not os.path.exists(tmp_path):
+        return False
+
+    try:
+        os.replace(tmp_path, cover_path)
+        with open(os.path.join(folder, COVER_SOURCE_FILENAME), "w", encoding="utf-8") as f:
+            f.write(art_url)
+    except Exception as exc:
+        log.warning("Could not store cover for feed %s: %s", getattr(feed, "id", "?"), exc)
+        return False
+
+    log.info("Fetched cover art for '%s' from %s", getattr(feed, "title", "") or "?", art_url)
+    return True
+
+
 def _download_image(url: str, dest_path: str) -> None:
     """Download an image from *url* to *dest_path*. Skips if file already exists."""
     from urllib.parse import urlparse
@@ -407,7 +484,16 @@ def _download_image(url: str, dest_path: str) -> None:
         with httpx.Client(
             timeout=httpx.Timeout(10, read=30),
             follow_redirects=True,
-            headers={"User-Agent": "CastCharm/1.0"},
+            # A browser-shaped User-Agent, because the server is now the only
+            # thing that fetches artwork. A host that serves images to browsers
+            # but refuses "CastCharm/1.0" would otherwise leave the user with no
+            # art at all, where before their own browser would have got it.
+            headers={
+                "User-Agent": (
+                    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+                    "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+                )
+            },
         ) as client:
             r = client.get(url)
             r.raise_for_status()
@@ -669,11 +755,16 @@ def download_episode(episode_id: int, db: Session) -> None:
 
         file_size = os.path.getsize(target_path)
 
-        # Save cover art sidecars
+        # Save cover art sidecars. Feed art goes through the same helper the
+        # refresh path uses, so "when may we write cover.jpg" is answered in one
+        # place and a download can no longer clobber a user's uploaded artwork.
         podcast_folder = os.path.join(base_dir, folder_name)
-        feed_art_url = feed.custom_image_url or feed.image_url
-        if feed_art_url:
-            _download_image(feed_art_url, os.path.join(podcast_folder, "cover.jpg"))
+        if ensure_feed_cover(feed, podcast_folder):
+            try:
+                from app.routers.feeds import invalidate_cover_cache
+                invalidate_cover_cache(podcast_folder)
+            except Exception:
+                pass
         ep_art_path = os.path.splitext(target_path)[0] + ".jpg"
         ep_art_url = episode.custom_image_url or episode.episode_image_url
         if ep_art_url:

--- a/app/routers/episodes.py
+++ b/app/routers/episodes.py
@@ -86,15 +86,25 @@ def _ep_out(ep: Episode) -> EpisodeOut:
         # Our own cover endpoint, never the feed's RSS artwork URL. Handing that
         # out made every episode row fetch art from the podcast host directly,
         # which disclosed the user's IP and reading habits to a third party — one
-        # feed page here issued 305 such requests. If no cover has been fetched
-        # yet the endpoint 404s and the client falls back to its placeholder,
-        # which is a local, private failure rather than a remote one.
-        out.feed_image_url = f"/api/feeds/{ep.feed_id}/cover.jpg"
-    # Prefer local art sidecar over remote URL when no custom_image_url is set
-    if not ep.custom_image_url and ep.file_path:
-        art_path = os.path.splitext(ep.file_path)[0] + ".jpg"
-        if os.path.exists(art_path):
-            out.episode_image_url = f"/api/episodes/{ep.id}/cover.jpg"
+        # feed page here issued 305 such requests. Resolved through the shared
+        # helper, which is cached per feed: the folder lookup behind it costs a
+        # settings query, and this runs once per episode.
+        from app.routers.feeds import feed_cover_url
+        from sqlalchemy.orm import object_session
+        out.feed_image_url = feed_cover_url(ep.feed, object_session(ep))
+    # Our local art sidecar, or nothing — never the RSS episode image URL.
+    # Passing that through is what kept episode rows fetching art from podcast
+    # hosts; it is also frequently not an image at all (This American Life's
+    # feed gives its own home page here, which the browser blocks as an opaque
+    # response). Rows without a sidecar fall back to the feed cover, which is
+    # served from here too.
+    if not ep.custom_image_url:
+        art_path = os.path.splitext(ep.file_path)[0] + ".jpg" if ep.file_path else None
+        out.episode_image_url = (
+            f"/api/episodes/{ep.id}/cover.jpg"
+            if art_path and os.path.exists(art_path)
+            else None
+        )
     # Flag downloaded episodes whose file has gone missing from disk
     if ep.status == "downloaded" and ep.file_path and not os.path.exists(ep.file_path):
         out.file_missing = True

--- a/app/routers/episodes.py
+++ b/app/routers/episodes.py
@@ -83,7 +83,13 @@ def _ep_out(ep: Episode) -> EpisodeOut:
     out = EpisodeOut.model_validate(ep)
     if ep.feed:
         out.feed_title = ep.feed.title
-        out.feed_image_url = ep.feed.image_url
+        # Our own cover endpoint, never the feed's RSS artwork URL. Handing that
+        # out made every episode row fetch art from the podcast host directly,
+        # which disclosed the user's IP and reading habits to a third party — one
+        # feed page here issued 305 such requests. If no cover has been fetched
+        # yet the endpoint 404s and the client falls back to its placeholder,
+        # which is a local, private failure rather than a remote one.
+        out.feed_image_url = f"/api/feeds/{ep.feed_id}/cover.jpg"
     # Prefer local art sidecar over remote URL when no custom_image_url is set
     if not ep.custom_image_url and ep.file_path:
         art_path = os.path.splitext(ep.file_path)[0] + ".jpg"

--- a/app/routers/feeds.py
+++ b/app/routers/feeds.py
@@ -127,18 +127,34 @@ def _merge_counts(primary_id: int, sub_ids: list[int], raw: dict[int, dict]) -> 
 # The TTL is a backstop for covers that appear by some path that forgets to
 # invalidate (a file dropped into the folder by hand, say). The explicit
 # invalidation below is what keeps it correct in normal use.
-_COVER_EXISTS_CACHE: dict[str, tuple[float, bool]] = {}
+_COVER_EXISTS_CACHE: dict[str, tuple[float, tuple[bool, bool]]] = {}
 _COVER_CACHE_TTL = 60.0
 
 
-def _has_local_cover(folder: str) -> bool:
+def _local_cover_state(folder: str) -> tuple[bool, bool]:
+    """
+    (a cover.jpg is on disk, that cover is the user's own artwork).
+
+    Both facts are resolved and cached together. Asking them separately would
+    put a second filesystem read on the same per-feed path the cache above
+    exists to keep off, undoing the measured win it was written for.
+    """
     now = time.monotonic()
     cached = _COVER_EXISTS_CACHE.get(folder)
     if cached is not None and now - cached[0] < _COVER_CACHE_TTL:
         return cached[1]
     exists = os.path.exists(os.path.join(folder, "cover.jpg"))
-    _COVER_EXISTS_CACHE[folder] = (now, exists)
-    return exists
+    user_owned = False
+    if exists:
+        from app.downloader import read_cover_source
+        user_owned = read_cover_source(folder) is None
+    state = (exists, user_owned)
+    _COVER_EXISTS_CACHE[folder] = (now, state)
+    return state
+
+
+def _has_local_cover(folder: str) -> bool:
+    return _local_cover_state(folder)[0]
 
 
 def invalidate_cover_cache(folder: str | None = None) -> None:
@@ -171,15 +187,26 @@ def _feed_out(feed: Feed, db: Session, counts: dict | None = None) -> FeedOut:
     data.needs_rename             = counts["needs_rename"]
     data.last_download_at         = counts["last_download_at"]
 
-    # Prefer local cover.jpg over remote URL when no custom_image_url is set
+    # Two questions that used to share one answer:
+    #   which URL should a client load?  — ours, whenever the file is on disk.
+    #   is that artwork the USER's?      — only if they set a custom URL or put
+    #                                      the file there themselves.
+    # Covers are now fetched for every feed, so answering the second with the
+    # first would have the settings panel claim custom artwork on all of them
+    # and offer to "remove" art the user never chose.
     has_custom_cover = bool(feed.custom_image_url)
     try:
         from app.downloader import get_podcast_folder
         folder = get_podcast_folder(feed, db)
         data.podcast_folder = folder
-        if not feed.custom_image_url and _has_local_cover(folder):
-            data.image_url = f"/api/feeds/{feed.id}/cover.jpg"
-            has_custom_cover = True
+        if not feed.custom_image_url:
+            exists, user_owned = _local_cover_state(folder)
+            # The RSS artwork URL is never passed on to clients, even when we
+            # have not managed to fetch it: doing so is what put the browser in
+            # direct contact with the podcast host. A feed whose art we could
+            # not retrieve shows a placeholder, and each sync tries again.
+            data.image_url = f"/api/feeds/{feed.id}/cover.jpg" if exists else None
+            has_custom_cover = exists and user_owned
     except Exception:
         pass
     data.has_custom_cover = has_custom_cover
@@ -600,7 +627,7 @@ def delete_feed(feed_id: int, delete_files: bool = False, force: bool = False, d
         # user's files must not quietly remove it.
         if podcast_folder and os.path.isdir(podcast_folder):
             invalidate_cover_cache()
-            for fname in ("cover.jpg", "complete-feed.xml", "castcharm.json"):
+            for fname in ("cover.jpg", ".cover-source", "complete-feed.xml", "castcharm.json"):
                 p = os.path.join(podcast_folder, fname)
                 if os.path.exists(p):
                     try:
@@ -763,7 +790,15 @@ def get_feed_episodes(
     else:
         episodes = q.offset(offset).limit(limit).all()
 
-    # Pre-resolve effective image URL for each feed in the group (cover.jpg > custom > RSS URL)
+    # Pre-resolve effective image URL for each feed in the group: cover.jpg, or
+    # the user's own custom URL, and otherwise nothing.
+    #
+    # The RSS artwork URL is deliberately NOT a fallback here. This endpoint
+    # builds a whole page of episode rows, so passing it through had every row
+    # fetch art from the podcast host — measured at 305 requests to one third
+    # party from a single feed page, each one disclosing the user's address and
+    # the moment they opened it. A missing cover is a placeholder now; the sync
+    # that fetches artwork will fill it in.
     feed_art: dict[int, str | None] = {}
     try:
         from app.downloader import get_podcast_folder
@@ -773,22 +808,23 @@ def get_feed_episodes(
             else:
                 try:
                     folder = get_podcast_folder(src, db)
-                    if folder and _has_local_cover(folder):
-                        feed_art[fid] = f"/api/feeds/{fid}/cover.jpg"
-                    else:
-                        feed_art[fid] = src.image_url
+                    feed_art[fid] = (
+                        f"/api/feeds/{fid}/cover.jpg"
+                        if folder and _has_local_cover(folder)
+                        else None
+                    )
                 except Exception:
-                    feed_art[fid] = src.image_url
+                    feed_art[fid] = None
     except Exception:
         for fid, src in feed_map.items():
-            feed_art[fid] = src.custom_image_url or src.image_url
+            feed_art[fid] = src.custom_image_url
 
     result = []
     for ep in episodes:
         out = EpisodeOut.model_validate(ep)
         src = feed_map.get(ep.feed_id, feed)
         out.feed_title = src.title
-        out.feed_image_url = feed_art.get(ep.feed_id, src.image_url)
+        out.feed_image_url = feed_art.get(ep.feed_id)
         # Prefer local art sidecar over remote URL when no custom_image_url is set
         if not ep.custom_image_url and ep.file_path:
             art_path = os.path.splitext(ep.file_path)[0] + ".jpg"
@@ -1343,6 +1379,11 @@ async def upload_feed_cover(
             raise HTTPException(status_code=400, detail="File is not a valid image")
         with open(cover_path, "wb") as f:
             f.write(contents)
+        # Hand ownership of this file to the user: dropping the source marker is
+        # what stops the next feed refresh from fetching the RSS artwork back
+        # over the top of what they just uploaded.
+        from app.downloader import clear_cover_source
+        clear_cover_source(folder)
         # The folder now has a cover that _feed_out would otherwise not notice
         # until the TTL lapsed.
         invalidate_cover_cache(folder)
@@ -1370,6 +1411,13 @@ def delete_feed_cover(feed_id: int, db: Session = Depends(get_db)):
         cover_path = os.path.join(folder, "cover.jpg")
         if os.path.exists(cover_path):
             os.remove(cover_path)
+        # Drop the marker too, so the folder is left in a clean state rather
+        # than one claiming a cover that is no longer there. The next refresh
+        # re-fetches the RSS artwork, which is the art the user is asking to
+        # fall back to — served by us, so removing a custom cover does not
+        # quietly put the browser back in touch with the podcast host.
+        from app.downloader import clear_cover_source
+        clear_cover_source(folder)
         invalidate_cover_cache(folder)
     except Exception:
         pass

--- a/app/routers/feeds.py
+++ b/app/routers/feeds.py
@@ -157,12 +157,52 @@ def _has_local_cover(folder: str) -> bool:
     return _local_cover_state(folder)[0]
 
 
+# Resolved artwork URL per feed id. Separate from the per-folder cache above
+# because the expensive part here is get_podcast_folder(), which costs a
+# settings query — and the callers include per-episode serialisation, where a
+# query each would be a page-load's worth of them.
+_FEED_COVER_URL_CACHE: dict[int, tuple[float, str | None]] = {}
+
+
+def feed_cover_url(feed, db) -> str | None:
+    """
+    The artwork URL a client should be handed for this feed: this server's cover
+    endpoint, the user's own custom URL, or nothing.
+
+    Never the feed's RSS artwork URL — serving that is what had browsers fetching
+    art straight from podcast hosts, disclosing the user's address and reading
+    times. Returning None where we hold no cover is deliberate: the client draws
+    its placeholder, which is a local, private failure. Pointing at a cover
+    endpoint that would 404 is not better; it just moves the noise.
+    """
+    if feed.custom_image_url:
+        return feed.custom_image_url
+    now = time.monotonic()
+    cached = _FEED_COVER_URL_CACHE.get(feed.id)
+    if cached is not None and now - cached[0] < _COVER_CACHE_TTL:
+        return cached[1]
+    url = None
+    try:
+        from app.downloader import get_podcast_folder
+        folder = get_podcast_folder(feed, db)
+        if folder and _has_local_cover(folder):
+            url = f"/api/feeds/{feed.id}/cover.jpg"
+    except Exception:
+        pass
+    _FEED_COVER_URL_CACHE[feed.id] = (now, url)
+    return url
+
+
 def invalidate_cover_cache(folder: str | None = None) -> None:
     """Forget cached cover state — for one folder, or all of them."""
     if folder is None:
         _COVER_EXISTS_CACHE.clear()
     else:
         _COVER_EXISTS_CACHE.pop(folder, None)
+    # The per-feed URL cache is keyed by id, so a folder-scoped invalidation
+    # cannot find its entry. It is small, and a cover change is rare, so drop
+    # the lot rather than leave a stale URL behind whichever way it is called.
+    _FEED_COVER_URL_CACHE.clear()
 
 
 def _feed_out(feed: Feed, db: Session, counts: dict | None = None) -> FeedOut:
@@ -199,14 +239,10 @@ def _feed_out(feed: Feed, db: Session, counts: dict | None = None) -> FeedOut:
         from app.downloader import get_podcast_folder
         folder = get_podcast_folder(feed, db)
         data.podcast_folder = folder
+        data.image_url = feed_cover_url(feed, db)
         if not feed.custom_image_url:
-            exists, user_owned = _local_cover_state(folder)
-            # The RSS artwork URL is never passed on to clients, even when we
-            # have not managed to fetch it: doing so is what put the browser in
-            # direct contact with the podcast host. A feed whose art we could
-            # not retrieve shows a placeholder, and each sync tries again.
-            data.image_url = f"/api/feeds/{feed.id}/cover.jpg" if exists else None
-            has_custom_cover = exists and user_owned
+            _, user_owned = _local_cover_state(folder)
+            has_custom_cover = data.image_url is not None and user_owned
     except Exception:
         pass
     data.has_custom_cover = has_custom_cover
@@ -799,25 +835,9 @@ def get_feed_episodes(
     # party from a single feed page, each one disclosing the user's address and
     # the moment they opened it. A missing cover is a placeholder now; the sync
     # that fetches artwork will fill it in.
-    feed_art: dict[int, str | None] = {}
-    try:
-        from app.downloader import get_podcast_folder
-        for fid, src in feed_map.items():
-            if src.custom_image_url:
-                feed_art[fid] = src.custom_image_url
-            else:
-                try:
-                    folder = get_podcast_folder(src, db)
-                    feed_art[fid] = (
-                        f"/api/feeds/{fid}/cover.jpg"
-                        if folder and _has_local_cover(folder)
-                        else None
-                    )
-                except Exception:
-                    feed_art[fid] = None
-    except Exception:
-        for fid, src in feed_map.items():
-            feed_art[fid] = src.custom_image_url
+    feed_art: dict[int, str | None] = {
+        fid: feed_cover_url(src, db) for fid, src in feed_map.items()
+    }
 
     result = []
     for ep in episodes:
@@ -825,11 +845,17 @@ def get_feed_episodes(
         src = feed_map.get(ep.feed_id, feed)
         out.feed_title = src.title
         out.feed_image_url = feed_art.get(ep.feed_id)
-        # Prefer local art sidecar over remote URL when no custom_image_url is set
-        if not ep.custom_image_url and ep.file_path:
-            art_path = os.path.splitext(ep.file_path)[0] + ".jpg"
-            if os.path.exists(art_path):
-                out.episode_image_url = f"/api/episodes/{ep.id}/cover.jpg"
+        # Local art sidecar or nothing, never the RSS URL — same rule as
+        # _ep_out in episodes.py, and for the same reason: this endpoint builds
+        # a whole page of rows, so a remote value here is a page-load's worth of
+        # requests to a podcast host.
+        if not ep.custom_image_url:
+            art_path = os.path.splitext(ep.file_path)[0] + ".jpg" if ep.file_path else None
+            out.episode_image_url = (
+                f"/api/episodes/{ep.id}/cover.jpg"
+                if art_path and os.path.exists(art_path)
+                else None
+            )
         if ep.status == "downloaded" and ep.file_path and not os.path.exists(ep.file_path):
             out.file_missing = True
         result.append(out)
@@ -1254,7 +1280,13 @@ def import_status(feed_id: int, db: Session = Depends(get_db)):
     from app.importer import get_import_status
     status = get_import_status(feed_id)
     if status is None:
-        raise HTTPException(status_code=404, detail="No import job found for this feed")
+        # "Nothing is importing" is an answer, not a missing resource — the
+        # import status of this feed exists, and its value is idle. Raising 404
+        # for it put a failed request and a console error on every feed page
+        # load, which is noise in the one place you go looking when something is
+        # actually wrong. Shape matches import_preview_status below, which has
+        # always answered the same question this way.
+        return {"status": "idle"}
     return status
 
 

--- a/app/routers/playlists.py
+++ b/app/routers/playlists.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
@@ -17,7 +18,19 @@ def _episode_out(ep: Episode, db: Session) -> EpisodeOut:
     feed = db.get(Feed, ep.feed_id)
     d = EpisodeOut.model_validate(ep)
     d.feed_title = feed.title if feed else None
-    d.feed_image_url = feed.image_url if feed else None
+    # Artwork always resolves to this server, never to the podcast host — the
+    # same rule the episodes and feeds routers follow. This one served RSS URLs
+    # straight from the feed record, so a playlist was one more page quietly
+    # telling third parties who was reading it and when.
+    from app.routers.feeds import feed_cover_url
+    d.feed_image_url = feed_cover_url(feed, db) if feed else None
+    if not ep.custom_image_url:
+        art_path = os.path.splitext(ep.file_path)[0] + ".jpg" if ep.file_path else None
+        d.episode_image_url = (
+            f"/api/episodes/{ep.id}/cover.jpg"
+            if art_path and os.path.exists(art_path)
+            else None
+        )
     return d
 
 

--- a/app/routers/stats.py
+++ b/app/routers/stats.py
@@ -409,13 +409,20 @@ def get_global_stats(db: Session = Depends(get_db)):
     partial_by = _partially_played_by_feed(all_feed_ids, db)
     played_not_dl_by = _played_not_downloaded_by_feed(all_feed_ids, db)
 
+    from app.routers.feeds import feed_cover_url
+
     by_feed = []
     for f in feeds:
         ids = sub_map[f.id]
         by_feed.append(FeedStatRow(
             feed_id=f.id,
             title=f.title or f.url,
-            image_url=f.custom_image_url or f.image_url,
+            # This server's cover endpoint, never the feed's RSS artwork URL.
+            # The stats page lists every feed at once, so serving raw URLs here
+            # meant opening it announced the user to one host per podcast they
+            # subscribe to. Resolved through the shared helper so feeds with no
+            # cover yield nothing rather than a URL that 404s.
+            image_url=feed_cover_url(f, db),
             episode_count=sum(total_by.get(i, 0) for i in ids),
             downloaded_count=sum(dl_by.get(i, 0) for i in ids),
             unplayed_count=sum(unplayed_by.get(i, 0) for i in ids),

--- a/app/rss_parser.py
+++ b/app/rss_parser.py
@@ -631,6 +631,21 @@ def sync_feed_episodes(
             new_pending_episodes.append(episode)
 
     db.flush()
+
+    # Pull the feed's artwork down while we are here. Every refresh path — the
+    # scheduler, a manual sync, an XML import, the startup scan — funnels through
+    # this function, so hooking it here is what makes "the server holds the art,
+    # not the browser" true everywhere rather than only where someone remembered.
+    # Best-effort: artwork must never be the reason a sync reports failure.
+    try:
+        from app.downloader import get_podcast_folder, ensure_feed_cover
+        from app.routers.feeds import invalidate_cover_cache
+        folder = get_podcast_folder(feed, db)
+        if ensure_feed_cover(feed, folder):
+            invalidate_cover_cache(folder)
+    except Exception as exc:
+        log.warning("Could not refresh cover art for feed %d: %s", feed.id, exc)
+
     new_ids = [ep.id for ep in new_pending_episodes]
     if new_ids:
         log.info(

--- a/static/views/feed-detail.js
+++ b/static/views/feed-detail.js
@@ -1050,9 +1050,12 @@ async function viewFeedDetail(feedId) {
     e.target.value = "";
     if (!file) return;
 
-    // Refuse here what the server would refuse anyway: upload_feed_cover accepts
-    // an image of at most 10 MB. Checking first turns a round trip and a rejected
-    // preview into immediate feedback.
+    // Catch the obviously-wrong pick before spending a round trip on it. This is
+    // a convenience, not a validation: file.type is derived from the extension,
+    // so a text file renamed to .jpg still reports image/jpeg and sails through
+    // to the server, which is the only thing that actually decodes the bytes
+    // (upload_feed_cover runs PIL verify, and rejects over 10 MB). The failure
+    // path below therefore has to stay just as good as this one.
     if (!file.type.startsWith("image/")) {
       Toast.error("That file is not an image");
       return;

--- a/static/views/feed-detail.js
+++ b/static/views/feed-detail.js
@@ -236,7 +236,11 @@ async function _pollImportBanner(feedId, refreshOnDone = false) {
   if (!banner) return;
 
   function _renderBanner(s) {
-    if (!s) { banner.style.display = "none"; return; }
+    // "idle" is the server saying no import is happening. It has to be caught
+    // here as well as the falsy case: it arrives as a perfectly good object, so
+    // without this the code falls through and paints an empty banner on every
+    // feed page — trading a silent console error for a visible one.
+    if (!s || s.status === "idle") { banner.style.display = "none"; return; }
     const isRunning = s.status === "running";
     const pct = s.total > 0 ? Math.round((s.processed / s.total) * 100) : 0;
     const renameN = s.rename_needed || 0;
@@ -282,7 +286,8 @@ async function _pollImportBanner(feedId, refreshOnDone = false) {
       await Promise.all([_refreshEpisodeList(), _refreshFeedStats()]);
     }
   } catch (_) {
-    // 404 means no import job yet — that's expected on a fresh page load
+    // Only a genuine failure reaches here now — "no import job" comes back as a
+    // normal idle response rather than as an error to be swallowed.
   }
 }
 


### PR DESCRIPTION
Fixed (hopefully for good) lots of places in the app where the server offloaded request URLs for images (cover art, episode art) to the user's browser. Everything is now handled server-side, so the user's browser doesn't need to look elsewhere for what it needs.